### PR TITLE
FIX:Traduccion de opciones de la pagina en general al Español

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/material": "^5.16.5",
         "@mui/styled-engine-sc": "^6.0.0-alpha.18",
         "@mui/styles": "^5.16.5",
-        "@mui/x-data-grid": "^7.3.1",
+        "@mui/x-data-grid": "^7.28.1",
         "@mui/x-date-pickers": "^7.6.1",
         "@types/xlsx": "^0.0.36",
         "autoprefixer": "^10.4.16",
@@ -162,9 +162,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
-      "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1531,16 +1532,18 @@
       }
     },
     "node_modules/@mui/x-data-grid": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.17.0.tgz",
-      "integrity": "sha512-d3pFdrQlNR+8waol7iM6LlNIpvqo9SgYeKcMIOSQ3etpue9iRFNy8s1HCHd9Nxnhzgr+fqMy/v3bXZnd196qig==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.28.1.tgz",
+      "integrity": "sha512-uDJcjRB7zfRoquZb4G8iw0NWbhziVVPsHisi/EIzvOPHP+a1ZUnG0bLEnY+cy6eEwDrO1dNzYpwGFCcjl8ZKfA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.25.6",
-        "@mui/utils": "^5.16.6",
-        "@mui/x-internals": "7.17.0",
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "@mui/x-internals": "7.28.0",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "reselect": "^5.1.1"
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1552,10 +1555,10 @@
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -1564,6 +1567,26 @@
         "@emotion/styled": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/@mui/x-internals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.28.0.tgz",
+      "integrity": "sha512-p4GEp/09bLDumktdIMiw+OF4p+pJOOjTG0VUvzNxjbHB9GxbBKoMcHrmyrURqoBnQpWIeFnN/QAoLMFSpfwQbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@mui/x-date-pickers": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@mui/material": "^5.16.5",
     "@mui/styled-engine-sc": "^6.0.0-alpha.18",
     "@mui/styles": "^5.16.5",
-    "@mui/x-data-grid": "^7.3.1",
+    "@mui/x-data-grid": "^7.28.1",
     "@mui/x-date-pickers": "^7.6.1",
     "@types/xlsx": "^0.0.36",
     "autoprefixer": "^10.4.16",

--- a/src/components/common/AddTextModal.tsx
+++ b/src/components/common/AddTextModal.tsx
@@ -15,17 +15,17 @@ const AddTextModal: FC<AddTextModalProps> = ({ isVisible, setIsVisible, onCreate
 
   const handleCreate = async () => {
     let rolWithTheSameName = false;
-    existingRoles.forEach(role=>{
-      if(name && role.name.toLowerCase() === name.toLowerCase()){
+    existingRoles.forEach(role => {
+      if (name && role.name.toLowerCase() === name.toLowerCase()) {
         rolWithTheSameName = true;
       }
     })
-    if(!name.trim()){
+    if (!name.trim()) {
       setError("El nombre del rol no puede estar vacío");
     } else if (rolWithTheSameName) {
       setError("Rol existente")
-    }else{
-      onCreate(name, isTeacher? "professor": "student");
+    } else {
+      onCreate(name, isTeacher ? "professor" : "student");
       setIsVisible(false);
       setName('');
       setError(null);
@@ -46,20 +46,22 @@ const AddTextModal: FC<AddTextModalProps> = ({ isVisible, setIsVisible, onCreate
       aria-describedby="create-modal-description"
     >
       <Box
-        className = 'modal-box'
+        className='modal-box'
       >
-        <IconButton 
-        sx={{position: 'absolute', top: 6, left: 450}}
-          onClick={toggleModal} 
+        <IconButton
+          sx={{ position: 'absolute', top: 6, left: 450 }}
+          onClick={toggleModal}
         >
-          <CancelIcon color = "primary"/>
+          <CancelIcon color="primary" />
         </IconButton>
-        <Typography id="create-modal-title" variant = 'h5'>Crear nuevo rol</Typography>
+        <Typography id="create-modal-title" variant='h5'>Crear nuevo rol</Typography>
         <TextField
           fullWidth
           value={name}
-          onChange={(e) => {setName(e.target.value);
-                            if (error) setError(null);}}
+          onChange={(e) => {
+            setName(e.target.value);
+            if (error) setError(null);
+          }}
           label="Ingresa el nombre del nuevo rol"
           variant="outlined"
           inputProps={{ maxLength: 25 }}
@@ -73,7 +75,7 @@ const AddTextModal: FC<AddTextModalProps> = ({ isVisible, setIsVisible, onCreate
           <Grid container sx={{ padding: 2, justifyContent: 'center' }} spacing={2}>
             <Grid item xs={5} md={6}>
               <Card variant="outlined">
-                <CardActionArea onClick={() => setIsTeacher(false)}> 
+                <CardActionArea onClick={() => setIsTeacher(false)}>
                   <CardContent sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                     <CardMedia>
                       <SchoolIcon sx={{ fontSize: 100 }} color="primary" />
@@ -106,7 +108,7 @@ const AddTextModal: FC<AddTextModalProps> = ({ isVisible, setIsVisible, onCreate
           </Grid>
         </Box>
 
-        <Box display="flex" justifyContent="flex-end" mt={2}  sx={{ marginTop: '20px' }}>
+        <Box display="flex" justifyContent="flex-end" mt={2} sx={{ marginTop: '20px' }}>
           <Button variant="outlined" color="secondary" onClick={toggleModal} sx={{ marginRight: '10px' }}>
             Cancelar
           </Button>

--- a/src/components/common/CalendarComponent.tsx
+++ b/src/components/common/CalendarComponent.tsx
@@ -2,9 +2,45 @@ import { Card, CardContent, Typography } from "@mui/material";
 // @ts-ignore
 import { Calendar, momentLocalizer } from "react-big-calendar";
 import moment from "moment";
+import "moment/locale/es";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 
+moment.locale("es");
 const localizer = momentLocalizer(moment);
+
+moment.updateLocale("es", {
+  week: {
+    dow: 1,
+  },
+  months: [
+    "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
+    "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre",
+  ],
+  monthsShort: [
+    "Ene", "Feb", "Mar", "Abr", "May", "Jun",
+    "Jul", "Ago", "Sep", "Oct", "Nov", "Dic",
+  ],
+  weekdays: [
+    "Domingo", "Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado",
+  ],
+  weekdaysShort: ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"],
+});
+
+const messages = {
+  today: "Hoy",
+  previous: "Atrás",
+  next: "Siguiente",
+  month: "Mes",
+  week: "Semana",
+  day: "Día",
+  agenda: "Agenda",
+  date: "Fecha",
+  time: "Hora",
+  event: "Evento",
+  noEventsInRange: "No hay eventos en este rango.",
+  showMore: (total: number) => `+ Ver más (${total})`,
+};
+
 
 // Componente CalendarCard
 // @ts-ignore
@@ -32,6 +68,7 @@ const CalendarCard = ({ events }) => {
             startAccessor="start"
             endAccessor="end"
             style={{ height: "100%" }}
+            messages={messages}
           />
         </div>
       </CardContent>

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -21,6 +21,16 @@ interface AppBarProps extends MuiAppBarProps {
 }
 const drawerWidth = 240;
 
+const traducirRol = (rol: string) => {
+  const rolesTraducidos: { [key: string]: string } = {
+    professor: "Profesor",
+    student: "Estudiante",
+    admin: "Administrador",
+  };
+  return rolesTraducidos[rol] || rol;
+};
+
+
 const AppBar = styled(MuiAppBar, {
   shouldForwardProp: (prop) => prop !== "open",
 })<AppBarProps>(({ theme, open }) => ({
@@ -117,11 +127,11 @@ const Layout = () => {
               color="textSecondary"
               textAlign={"right"}
             >
-              {user?.roles}
+              {traducirRol(user?.roles)}
             </Typography>
           </Box>
 
-          <Tooltip 
+          <Tooltip
             data-test-id="user_icon"
             title="Open settings">
             <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>

--- a/src/locales/datagridLocaleEs.ts
+++ b/src/locales/datagridLocaleEs.ts
@@ -1,0 +1,53 @@
+import { GridToolbarColumnsButton } from "@mui/x-data-grid";
+
+const dataGridLocaleText = {
+    MuiTablePagination: {
+        labelRowsPerPage: "Filas por página",
+        labelDisplayedRows: ({ from, to, count }) =>
+            `${from}–${to} de ${count !== -1 ? count : `más de ${to}`}`,
+    },
+    noRowsLabel: "No hay registros",
+    footerRowSelected: (count: number) =>
+        count > 1 ? `${count.toLocaleString()} filas seleccionadas` : `${count.toLocaleString()} fila seleccionada`,
+    columnMenuSortAsc: "Ordenar ascendente",
+    columnMenuSortDesc: "Ordenar descendente",
+    columnMenuFilter: "Filtrar",
+    columnMenuHideColumn: "Ocultar columna",
+    columnMenuShowColumns: "Mostrar columnas",
+    columnMenuUnsort: "Quitar orden",
+    columnMenuManageColumns: "Administrar columnas",
+
+    filterPanelTitle: "Filtros",
+    filterPanelColumns: "Columna",
+    filterPanelOperators: "Operador",
+    filterPanelValue: "Valor",
+    filterPanelAddFilter: "Agregar filtro",
+    filterPanelDeleteIconLabel: "Eliminar filtro",
+    filterPanelLogicOperator: "Operador lógico",
+    filterPanelLogicOperatorAnd: "Y",
+    filterPanelLogicOperatorOr: "O",
+    filterPanelInputLabel: "Valor del filtro",
+    filterPanelOperator: "Operador",
+
+    filterOperatorContains: "Contiene",
+    filterOperatorDoesNotContain: "No contiene",
+    filterOperatorEquals: "Igual a",
+    filterOperatorDoesNotEqual: "No es igual a",
+    filterOperatorStartsWith: "Empieza con",
+    filterOperatorEndsWith: "Termina con",
+    filterOperatorIs: "Es",
+    filterOperatorNot: "No es",
+    filterOperatorAfter: "Después de",
+    filterOperatorOnOrAfter: "En o después de",
+    filterOperatorBefore: "Antes de",
+    filterOperatorOnOrBefore: "En o antes de",
+    filterOperatorIsEmpty: "Está vacío",
+    filterOperatorIsNotEmpty: "No está vacío",
+    filterOperatorIsAnyOf: "Es uno de",
+    
+    filterPanelInputPlaceholder: "Valor",
+
+    noResultsOverlayLabel: "No hay resultados",
+};
+
+export default dataGridLocaleText;

--- a/src/pages/Events/EventRegisterPage.tsx
+++ b/src/pages/Events/EventRegisterPage.tsx
@@ -22,6 +22,7 @@ import {
   updateInternType,
 } from "../../services/eventsService";
 import ConfirmDialog from "../../components/common/ConfirmDialog";
+import dataGridLocaleText from "../../locales/datagridLocaleEs";
 
 const EventRegisterPage = () => {
   const [addStudentOpen, setAddStudentOpen] = useState(false);
@@ -222,6 +223,7 @@ const EventRegisterPage = () => {
               <DataGrid
                 rows={students}
                 columns={columns}
+                localeText={dataGridLocaleText}
                 initialState={{
                   pagination: {
                     paginationModel: { page: 0, pageSize: 5 },

--- a/src/pages/Events/EventTable.tsx
+++ b/src/pages/Events/EventTable.tsx
@@ -6,7 +6,7 @@ import VisibilityIcon from "@mui/icons-material/Visibility";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
-import {} from "@mui/material";
+import { } from "@mui/material";
 import dayjs from "dayjs";
 import ContainerPage from "../../components/common/ContainerPage";
 import {
@@ -19,6 +19,7 @@ import {
 } from "../../models/eventInterface";
 import ConfirmDialog from "../../components/common/ConfirmDialog";
 import { getInternData } from "../../services/internService";
+import dataGridLocaleText from "../../locales/datagridLocaleEs";
 
 const EventTable = () => {
   const navigate = useNavigate();
@@ -266,6 +267,7 @@ const EventTable = () => {
           <DataGrid
             rows={eventsSupervisor || []}
             columns={columns}
+            localeText={dataGridLocaleText}
             getRowId={(row) => row.id}
             autoHeight
             initialState={{

--- a/src/pages/Professor/ProfessorPage.tsx
+++ b/src/pages/Professor/ProfessorPage.tsx
@@ -19,6 +19,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import { Permission } from "../../models/permissionInterface";
 import { getPermissionById } from "../../services/permissionsService";
 import { HasPermission } from "../../helper/permissions";
+import dataGridLocaleText from "../../locales/datagridLocaleEs";
 
 const ProfessorPage = () => {
   const navigate = useNavigate();
@@ -203,6 +204,7 @@ const ProfessorPage = () => {
           <DataGrid
             rows={professors}
             columns={columns}
+            localeText={dataGridLocaleText}
             initialState={{
               pagination: {
                 paginationModel: { page: 0, pageSize: 5 },

--- a/src/pages/Student/StudentsPage.tsx
+++ b/src/pages/Student/StudentsPage.tsx
@@ -19,6 +19,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import { getPermissionById } from "../../services/permissionsService";
 import { HasPermission } from "../../helper/permissions";
 import { Permission } from "../../models/permissionInterface";
+import dataGridLocaleText from "../../locales/datagridLocaleEs";
 
 const StudentPage = () => {
   const navigate = useNavigate();
@@ -185,6 +186,7 @@ const StudentPage = () => {
           <DataGrid
             rows={students}
             columns={columns}
+            localeText={dataGridLocaleText}
             initialState={{
               pagination: {
                 paginationModel: { page: 0, pageSize: 5 },

--- a/src/pages/Users/UsersPage.tsx
+++ b/src/pages/Users/UsersPage.tsx
@@ -18,6 +18,7 @@ import { RolePermissions } from "../../models/rolePermissionInterface";
 import { Permission } from "../../models/permissionInterface";
 import { getPermissionById } from "../../services/permissionsService";
 import { HasPermission } from "../../helper/permissions";
+import dataGridLocaleText from "../../locales/datagridLocaleEs";
 
 const UsersPage = () => {
   const navigate = useNavigate()
@@ -44,9 +45,9 @@ const UsersPage = () => {
       setEditUserPermission(editUserResponse.data[0]);
       const addUserResponse = await getPermissionById(22);
       setAddUserPermission(addUserResponse.data[0]);
-      console.log("permissos:",addUserPermission);
+      console.log("permissos:", addUserPermission);
     };
-    
+
     fetchPermissions();
   }, []);
 
@@ -101,7 +102,7 @@ const UsersPage = () => {
       setFilterRoles(selectedRole);
     }
   };
-  
+
 
   useEffect(() => {
     applyFilters();
@@ -190,12 +191,12 @@ const UsersPage = () => {
         <div>
           {HasPermission(viewUserReport?.name || "") && (
             <IconButton
-            color="primary"
-            aria-label="ver"
-            onClick={() => handleView(params.row.id)}
-          >
-            <VisibilityIcon />
-          </IconButton>)}
+              color="primary"
+              aria-label="ver"
+              onClick={() => handleView(params.row.id)}
+            >
+              <VisibilityIcon />
+            </IconButton>)}
           {HasPermission(editUserPermission?.name || "") && (
             <IconButton
               color="primary"
@@ -220,13 +221,13 @@ const UsersPage = () => {
   ]
 
   const fetchUsers = async () => {
-    
+
     const dataResponse = await getUsers()
     const usersResponse = dataResponse.data;
     for (const user of usersResponse) {
       user.fullName = `${user.name} ${user.lastname} ${user.mothername}`
       user.roles = []
-      for(const key in user.rolesAndPermissions)
+      for (const key in user.rolesAndPermissions)
         user.roles.push(user.rolesAndPermissions[key].role_name)
     }
     setUsers(usersResponse)
@@ -262,7 +263,7 @@ const UsersPage = () => {
     <ContainerPage
       title={`Usuarios (${users.length})`}
       subtitle={"Lista de usuarios"}
-      actions={HasPermission(addUserPermission?.name || "Agregar usuario")&&
+      actions={HasPermission(addUserPermission?.name || "Agregar usuario") &&
         (
           <Button
             variant="contained"
@@ -307,9 +308,9 @@ const UsersPage = () => {
                   onChange={handleSelectRoleChange}
                   value={filterRoles}
                 >
-                <MenuItem value="reset">
-                  Borrar búsqueda
-                </MenuItem>
+                  <MenuItem value="reset">
+                    Borrar búsqueda
+                  </MenuItem>
                   {roles.map((rol: Role) => (
                     <MenuItem value={rol.name}>{rol.name} ({countStudentsWithRole(rol.name)})</MenuItem>
                   ))}
@@ -321,6 +322,7 @@ const UsersPage = () => {
             <DataGrid
               rows={filteredUsers}
               columns={columns}
+              localeText={dataGridLocaleText}
               initialState={{
                 pagination: {
                   paginationModel: { page: 0, pageSize: 5 },

--- a/src/pages/interns/EventsByInterns.tsx
+++ b/src/pages/interns/EventsByInterns.tsx
@@ -9,6 +9,7 @@ import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { getAllCompleteInternService } from "../../services/internService";
 import { IconButton, Tooltip } from "@mui/material";
 import { CompleteIntern } from "../../models/internsInterface";
+import dataGridLocaleText from "../../locales/datagridLocaleEs";
 
 const EventByInterns = () => {
   const [detailOpen, setDetailOpen] = useState(false);
@@ -113,6 +114,7 @@ const EventByInterns = () => {
         <DataGrid
           rows={students}
           columns={columns}
+          localeText={dataGridLocaleText}
           initialState={{
             pagination: {
               paginationModel: { page: 0, pageSize: 5 },
@@ -150,7 +152,7 @@ const EventByInterns = () => {
           <IconButton
             aria-label="close"
             onClick={handleEditHoursClose}
-            style={{ color: '#231F74', position:'absolute', right:3, top:11}}
+            style={{ color: '#231F74', position: 'absolute', right: 3, top: 11 }}
           >
             <CancelIcon />
           </IconButton>

--- a/src/pages/interns/InternsListPage.tsx
+++ b/src/pages/interns/InternsListPage.tsx
@@ -22,6 +22,7 @@ import {
   updateInternType,
 } from "../../services/eventsService";
 import { internRegisterStates } from "../../constants/internRegisterStates";
+import dataGridLocaleText from "../../locales/datagridLocaleEs";
 
 interface FullEvent extends Event {
   interns: any[];
@@ -220,6 +221,7 @@ const InternsListPage = () => {
                 <DataGrid
                   rows={students}
                   columns={columns}
+                  localeText={dataGridLocaleText}
                   initialState={{
                     pagination: {
                       paginationModel: { page: 0, pageSize: 5 },

--- a/src/pages/interns/MyEventsTable.tsx
+++ b/src/pages/interns/MyEventsTable.tsx
@@ -22,6 +22,7 @@ import {
 import { deleteInternFromEventService } from "../../services/eventsService";
 import { EventInternsType } from "../../models/eventInterface";
 import { InternsInformation } from "../../models/internsInterface";
+import dataGridLocaleText from "../../locales/datagridLocaleEs";
 
 interface RowData {
   id?: number;
@@ -254,6 +255,7 @@ const MyEventsTable = () => {
             <DataGrid
               rows={rows || []}
               columns={columns}
+              localeText={dataGridLocaleText}
               initialState={{
                 pagination: {
                   paginationModel: { page: 0, pageSize: 5 },


### PR DESCRIPTION
**Se ha traducido al español los componentes MUI del proyecto.**

Se ha tenido que crear un archivo de traducciones global para poder llamarlo desde cualquier punto para traducir tablas, calendarios, etc. si asi se lo desea. Ya que las librerías oficiales MUI para traducir al español o estaban deprecadas o no funcionan del todo bien asi que creando nuestras propias traducciones también podemos poner en nuestras propias palabras la traducción para que este mas acorde con el contexto

Ojo, aplica para cada componente MUI que se desea usar, (Grid, calendar,  etc) 