### PR TITLE
FIX:Traduccion de elementos MUI de la pagina en general al Español

### DIFF
--- a/src/locales/datagridLocaleEs.ts
+++ b/src/locales/datagridLocaleEs.ts
@@ -1,5 +1,3 @@
-import { GridToolbarColumnsButton } from "@mui/x-data-grid";
-
 const dataGridLocaleText = {
     MuiTablePagination: {
         labelRowsPerPage: "Filas por página",
@@ -44,10 +42,15 @@ const dataGridLocaleText = {
     filterOperatorIsEmpty: "Está vacío",
     filterOperatorIsNotEmpty: "No está vacío",
     filterOperatorIsAnyOf: "Es uno de",
-    
+
     filterPanelInputPlaceholder: "Valor",
 
     noResultsOverlayLabel: "No hay resultados",
+
+    columnsManagementSearchTitle: "Buscar",
+    columnsManagementShowHideAllText: "Mostrar/Ocultar todo",
+    columnsManagementReset: "Restablecer",
+    columnsManagementNoColumns: "No hay columnas",
 };
 
 export default dataGridLocaleText;


### PR DESCRIPTION
Se ha traducido al español los componentes MUI del proyecto.

Se ha tenido que crear un archivo de traducciones global para poder llamarlo desde cualquier punto para traducir tablas, calendarios, etc. si asi se lo desea. Ya que las librerías oficiales MUI para traducir al español o estaban deprecadas o no funcionan del todo bien asi que creando nuestras propias traducciones también podemos poner en nuestras propias palabras la traducción para que este mas acorde con el contexto

Ojo, aplica para cada componente MUI que se desea usar, (Grid, calendar, etc)

A continuación un ejemplo:

![image](https://github.com/user-attachments/assets/fa0cf122-ff2f-447c-ad08-2873c545470d)
