### PR TITLE
Task51/OptionsTraduction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/material": "^5.16.5",
         "@mui/styled-engine-sc": "^6.0.0-alpha.18",
         "@mui/styles": "^5.16.5",
-        "@mui/x-data-grid": "^7.28.2",
+        "@mui/x-data-grid": "^7.3.1",
         "@mui/x-date-pickers": "^7.6.1",
         "@types/xlsx": "^0.0.36",
         "autoprefixer": "^10.4.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/material": "^5.16.5",
         "@mui/styled-engine-sc": "^6.0.0-alpha.18",
         "@mui/styles": "^5.16.5",
-        "@mui/x-data-grid": "^7.28.1",
+        "@mui/x-data-grid": "^7.28.2",
         "@mui/x-date-pickers": "^7.6.1",
         "@types/xlsx": "^0.0.36",
         "autoprefixer": "^10.4.16",
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@mui/x-data-grid": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.28.1.tgz",
-      "integrity": "sha512-uDJcjRB7zfRoquZb4G8iw0NWbhziVVPsHisi/EIzvOPHP+a1ZUnG0bLEnY+cy6eEwDrO1dNzYpwGFCcjl8ZKfA==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.28.2.tgz",
+      "integrity": "sha512-ac/CPZ/zOeHjCvv3LwTUSFy+dofELP/Cl2nXLYWrqVHUgFAkkWxhk85kiI/N1G+Rf4WiKw+oJfeyGe8ZSeY4tg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.7",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@mui/material": "^5.16.5",
     "@mui/styled-engine-sc": "^6.0.0-alpha.18",
     "@mui/styles": "^5.16.5",
-    "@mui/x-data-grid": "^7.28.2",
+    "@mui/x-data-grid": "^7.3.1",
     "@mui/x-date-pickers": "^7.6.1",
     "@types/xlsx": "^0.0.36",
     "autoprefixer": "^10.4.16",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@mui/material": "^5.16.5",
     "@mui/styled-engine-sc": "^6.0.0-alpha.18",
     "@mui/styles": "^5.16.5",
-    "@mui/x-data-grid": "^7.28.1",
+    "@mui/x-data-grid": "^7.28.2",
     "@mui/x-date-pickers": "^7.6.1",
     "@types/xlsx": "^0.0.36",
     "autoprefixer": "^10.4.16",

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -21,13 +21,13 @@ interface AppBarProps extends MuiAppBarProps {
 }
 const drawerWidth = 240;
 
-const traducirRol = (rol: string) => {
-  const rolesTraducidos: { [key: string]: string } = {
+const TranslateRole = (rol: string) => {
+  const translatedRoles: { [key: string]: string } = {
     professor: "Profesor",
     student: "Estudiante",
     admin: "Administrador",
   };
-  return rolesTraducidos[rol] || rol;
+  return translatedRoles[rol] || rol;
 };
 
 
@@ -127,7 +127,7 @@ const Layout = () => {
               color="textSecondary"
               textAlign={"right"}
             >
-              {traducirRol(user?.roles)}
+              {TranslateRole(user?.roles)}
             </Typography>
           </Box>
 

--- a/src/pages/Events/EventTable.tsx
+++ b/src/pages/Events/EventTable.tsx
@@ -6,7 +6,6 @@ import VisibilityIcon from "@mui/icons-material/Visibility";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
-import {} from "@mui/material";
 import dayjs from "dayjs";
 import ContainerPage from "../../components/common/ContainerPage";
 import {

--- a/src/pages/Events/EventTable.tsx
+++ b/src/pages/Events/EventTable.tsx
@@ -6,7 +6,7 @@ import VisibilityIcon from "@mui/icons-material/Visibility";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
-import { } from "@mui/material";
+import {} from "@mui/material";
 import dayjs from "dayjs";
 import ContainerPage from "../../components/common/ContainerPage";
 import {


### PR DESCRIPTION
Se ha traducido al español los componentes MUI del proyecto.

Se ha tenido que crear un archivo de traducciones global para poder llamarlo desde cualquier punto para traducir tablas, calendarios, etc. si asi se lo desea. Ya que las librerías oficiales MUI para traducir al español o estaban deprecadas o no funcionan del todo bien asi que creando nuestras propias traducciones también podemos poner en nuestras propias palabras la traducción para que este mas acorde con el contexto

Ojo, aplica para cada componente MUI que se desea usar, (Grid, calendar, etc)

A continuación un ejemplo:

![image](https://github.com/user-attachments/assets/fa0cf122-ff2f-447c-ad08-2873c545470d)

NOTA: se actualizo MUI Grid a la ultima versión y se limpio el código, libre de redundancias y con nombres de funciones en ingles
